### PR TITLE
Fix text running out of job boxes

### DIFF
--- a/static/less/layout.less
+++ b/static/less/layout.less
@@ -47,6 +47,7 @@ h1 {
     font-size: 30px;
     font-weight: 100;
   }
+  overflow: hidden;
 }
 
 .navbar-right {


### PR DESCRIPTION
Set overflow: hidden; on job CSS class in order to prevent the text in the job boxes from 'running out of the box' and messing up the page (this might happen for location values such as 'Referentenbetreuung')
